### PR TITLE
Eventsubtyping

### DIFF
--- a/src/main/java/se/sics/kompics/testing/EventLabel.java
+++ b/src/main/java/se/sics/kompics/testing/EventLabel.java
@@ -22,11 +22,10 @@
 package se.sics.kompics.testing;
 
 import com.google.common.base.Predicate;
+import java.util.Comparator;
 import se.sics.kompics.KompicsEvent;
 import se.sics.kompics.Port;
 import se.sics.kompics.PortType;
-
-import java.util.Comparator;
 
 /**
  * A state transition label in the NFA that matches a single
@@ -109,7 +108,7 @@ class EventLabel implements SingleLabel {
     // Return true if this label's predicate matches the observed event.
     private boolean predicateMatch(KompicsEvent observed) {
         // Is this the expected class of event?
-        if (eventType != observed.getClass())
+        if (!(eventType.isAssignableFrom(observed.getClass())))
             return false;
 
         // If yes, Invoke predicate with the observed event.

--- a/src/test/java/se/sics/kompics/testing/EventSubtypeTest.java
+++ b/src/test/java/se/sics/kompics/testing/EventSubtypeTest.java
@@ -1,0 +1,86 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package se.sics.kompics.testing;
+
+import com.google.common.base.Predicate;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import se.sics.kompics.Component;
+import se.sics.kompics.Port;
+import se.sics.kompics.testing.eventsubtype.AComp;
+import se.sics.kompics.testing.eventsubtype.APort;
+import se.sics.kompics.testing.eventsubtype.EventA;
+import se.sics.kompics.testing.eventsubtype.EventB;
+import se.sics.kompics.testing.eventsubtype.EventInterface;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class EventSubtypeTest {
+
+  @Test
+  public void test1() {
+    TestContext<AComp> tc = TestContext.newInstance(AComp.class);
+    Component comp = tc.getComponentUnderTest();
+    Port<APort> port = comp.getNegative(APort.class);
+
+    tc = tc.body()
+      .trigger(new EventA(), port)
+      .expect(EventInterface.class, eventB1(), port, Direction.OUT)
+      .repeat(1).body().end();
+
+    assertTrue(tc.check());
+  }
+  
+  //@Test
+  public void test2() {
+    TestContext<AComp> tc = TestContext.newInstance(AComp.class);
+    Component comp = tc.getComponentUnderTest();
+    Port<APort> port = comp.getNegative(APort.class);
+
+    tc = tc.body()
+      .trigger(new EventA(), port)
+      .expect(EventB.class, eventB2(), port, Direction.OUT)
+      .repeat(1).body().end();
+
+    assertTrue(tc.check());
+  }
+
+  Predicate<EventInterface> eventB1() {
+    return new Predicate<EventInterface>() {
+
+      @Override
+      public boolean apply(EventInterface t) {
+        return t instanceof EventB;
+      }
+    };
+  }
+  
+  Predicate<EventB> eventB2() {
+    return new Predicate<EventB>() {
+
+      @Override
+      public boolean apply(EventB t) {
+        return t instanceof EventB;
+      }
+    };
+  }
+}

--- a/src/test/java/se/sics/kompics/testing/eventsubtype/AComp.java
+++ b/src/test/java/se/sics/kompics/testing/eventsubtype/AComp.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package se.sics.kompics.testing.eventsubtype;
+
+import se.sics.kompics.ComponentDefinition;
+import se.sics.kompics.Handler;
+import se.sics.kompics.Positive;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class AComp extends ComponentDefinition {
+  Positive<APort> testP = requires(APort.class);
+  
+  public AComp() {
+    subscribe(handleTestA, testP);
+  }
+  
+  Handler handleTestA = new Handler<EventA>() {
+    @Override
+    public void handle(EventA event) {
+      trigger(new EventB(), testP);
+    }
+  };
+}

--- a/src/test/java/se/sics/kompics/testing/eventsubtype/APort.java
+++ b/src/test/java/se/sics/kompics/testing/eventsubtype/APort.java
@@ -1,0 +1,34 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package se.sics.kompics.testing.eventsubtype;
+
+import se.sics.kompics.PortType;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class APort extends PortType {
+
+  {
+    request(EventInterface.class);
+    indication(EventInterface.class);
+  }
+}

--- a/src/test/java/se/sics/kompics/testing/eventsubtype/EventA.java
+++ b/src/test/java/se/sics/kompics/testing/eventsubtype/EventA.java
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package se.sics.kompics.testing.eventsubtype;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class EventA implements EventInterface {
+}

--- a/src/test/java/se/sics/kompics/testing/eventsubtype/EventB.java
+++ b/src/test/java/se/sics/kompics/testing/eventsubtype/EventB.java
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package se.sics.kompics.testing.eventsubtype;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class EventB implements EventInterface {
+}

--- a/src/test/java/se/sics/kompics/testing/eventsubtype/EventInterface.java
+++ b/src/test/java/se/sics/kompics/testing/eventsubtype/EventInterface.java
@@ -1,0 +1,29 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package se.sics.kompics.testing.eventsubtype;
+
+import se.sics.kompics.KompicsEvent;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public interface EventInterface extends KompicsEvent {
+}


### PR DESCRIPTION
event subtyping is not working.
[test1](https://github.com/Decentrify/kompics-testing/blob/eventsubtyping/src/test/java/se/sics/kompics/testing/EventSubtypeTest.java#L40) fails as matching inside the testing framework is done on [exact event type](https://github.com/kompics/kompics-testing/blob/master/src/main/java/se/sics/kompics/testing/EventLabel.java#L112)
[test2](https://github.com/Decentrify/kompics-testing/blob/eventsubtyping/src/test/java/se/sics/kompics/testing/EventSubtypeTest.java#L54) throws an error as [APort](https://github.com/Decentrify/kompics-testing/blob/eventsubtyping/src/test/java/se/sics/kompics/testing/eventsubtype/APort.java) does not declare the subtype events EventA and EventB and instead declares the interface EventInterface.
As a practical example - network port declares Msg.class events but everyone will actually send subtypes of these events through the port.

I submitter the test case first inca se you want to run/debug the test on the old code:
https://github.com/Decentrify/kompics-testing/commit/886679e39ab39ce394734af477d3f1f2ad56d870
