### PR TITLE
Trigger with context (version with future)

### DIFF
--- a/src/main/java/se/sics/kompics/testing/InternalLabel.java
+++ b/src/main/java/se/sics/kompics/testing/InternalLabel.java
@@ -116,7 +116,7 @@ class InternalLabel implements Label {
     // Trigger an event on the specified port.
     private String doTrigger() {
         // Were we provided with an event to trigger?
-        if (event == null) {
+        if (event == null || future != null) {
             // If no, get event from provided future.
             event = future.get();
             if (event == null) {

--- a/src/test/java/se/sics/kompics/testing/TriggerWithContextTest.java
+++ b/src/test/java/se/sics/kompics/testing/TriggerWithContextTest.java
@@ -1,0 +1,95 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package se.sics.kompics.testing;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import se.sics.kompics.Component;
+import se.sics.kompics.KompicsEvent;
+import se.sics.kompics.Port;
+import se.sics.kompics.testing.triggercontext.AComp;
+import se.sics.kompics.testing.triggercontext.APort;
+import se.sics.kompics.testing.triggercontext.EventA;
+import se.sics.kompics.testing.triggercontext.EventB;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class TriggerWithContextTest {
+
+  @Test
+  public void test1() {
+    TestContext<AComp> tc = TestContext.newInstance(AComp.class);
+    Component comp = tc.getComponentUnderTest();
+    Port<APort> port = comp.getNegative(APort.class);
+
+    tc = tc.body();
+    tc = repeatedEvents(tc, port);
+    tc = repeatedEvents(tc, port);
+    tc = repeatedEvents(tc, port);
+    tc = repeatedEvents(tc, port);
+    tc = tc.repeat(1).body().end();
+
+    assertTrue(tc.check());
+  }
+  
+  @Test
+  public void test2() {
+    TestContext<AComp> tc = TestContext.newInstance(AComp.class);
+    Component comp = tc.getComponentUnderTest();
+    Port<APort> port = comp.getNegative(APort.class);
+
+    tc = tc.body();
+    tc = tc.repeat(5).body();
+    tc = repeatedEvents(tc, port);
+    tc = tc.end();
+    tc = tc.repeat(1).body().end();
+
+    assertTrue(tc.check());
+  }
+
+  private TestContext repeatedEvents(TestContext tc, Port port) {
+    Future f = repeatedFuture();
+    return tc
+      .trigger(new EventA(10), port)
+      .answerRequest(EventB.class, port, f)
+      .repeat(AComp.COUNTER).body()
+      .trigger(f, port)
+      .end();
+  }
+
+  private Future repeatedFuture() {
+    return new Future() {
+      int i = 0;
+
+      @Override
+      public boolean set(KompicsEvent request) {
+        i = 0; //reset
+        return true;
+      }
+
+      @Override
+      public KompicsEvent get() {
+        return new EventA(i++);
+      }
+    };
+  }
+}

--- a/src/test/java/se/sics/kompics/testing/triggercontext/AComp.java
+++ b/src/test/java/se/sics/kompics/testing/triggercontext/AComp.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package se.sics.kompics.testing.triggercontext;
+
+import se.sics.kompics.ComponentDefinition;
+import se.sics.kompics.Handler;
+import se.sics.kompics.Positive;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class AComp extends ComponentDefinition {
+
+  public static final int COUNTER = 10;
+  Positive<APort> testP = requires(APort.class);
+
+  int i = 10;
+
+  public AComp() {
+    subscribe(handleTestA, testP);
+  }
+
+  Handler handleTestA = new Handler<EventA>() {
+    @Override
+    public void handle(EventA event) {
+      if (i < COUNTER) {
+        if (event.i == i) {
+          i++;
+        }
+      } else {
+        trigger(new EventB(), testP);
+        i = 0;
+      }
+    }
+  };
+}

--- a/src/test/java/se/sics/kompics/testing/triggercontext/APort.java
+++ b/src/test/java/se/sics/kompics/testing/triggercontext/APort.java
@@ -1,0 +1,34 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+package se.sics.kompics.testing.triggercontext;
+
+import se.sics.kompics.PortType;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class APort extends PortType {
+
+  {
+    indication(EventA.class);
+    request(EventB.class);
+  }
+}

--- a/src/test/java/se/sics/kompics/testing/triggercontext/EventA.java
+++ b/src/test/java/se/sics/kompics/testing/triggercontext/EventA.java
@@ -1,0 +1,33 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package se.sics.kompics.testing.triggercontext;
+
+import se.sics.kompics.KompicsEvent;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class EventA implements KompicsEvent {
+  public final int i;
+  public EventA(int i) {
+    this.i = i;
+  }
+}

--- a/src/test/java/se/sics/kompics/testing/triggercontext/EventB.java
+++ b/src/test/java/se/sics/kompics/testing/triggercontext/EventB.java
@@ -1,0 +1,29 @@
+/**
+ * This file is part of the Kompics Testing runtime.
+ *
+ * Copyright (C) 2017 Swedish Institute of Computer Science (SICS)
+ * Copyright (C) 2017 Royal Institute of Technology (KTH)
+ *
+ * Kompics is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package se.sics.kompics.testing.triggercontext;
+
+import se.sics.kompics.KompicsEvent;
+
+/**
+ * @author Alex Ormenisan <aaor@kth.se>
+ */
+public class EventB implements KompicsEvent {
+}


### PR DESCRIPTION
A proposed fix to allow a future to be used in a repeat section thus allowing 1 request - multi response. The responses can be generated based on the request, thus the future acts as a context for the response generation.